### PR TITLE
Ability to set custom ListSectionAdapter or custom section header layout

### DIFF
--- a/supersaiyan-scrollview/src/com/nolanlawson/supersaiyan/SectionedListAdapter.java
+++ b/supersaiyan-scrollview/src/com/nolanlawson/supersaiyan/SectionedListAdapter.java
@@ -62,7 +62,7 @@ public class SectionedListAdapter< T extends BaseAdapter> extends BaseAdapter im
      * @param context
      */
     private SectionedListAdapter(Context context) {
-        this.sectionTitleAdapter = new SectionTitleAdapter(context, R.layout.list_header);
+        super();
     }
     
     /**
@@ -76,6 +76,10 @@ public class SectionedListAdapter< T extends BaseAdapter> extends BaseAdapter im
     
     public boolean isShowListTitles() {
         return showSectionTitles;
+    }
+
+    public void setSectionTitleAdapter(SectionTitleAdapter sectionTitleAdapter) {
+        this.sectionTitleAdapter = sectionTitleAdapter;
     }
 
     /**
@@ -514,6 +518,7 @@ public class SectionedListAdapter< T extends BaseAdapter> extends BaseAdapter im
         private Builder(Context context, T subAdapter) {
             adapter = new SectionedListAdapter<T>(context);
             adapter.setSubAdapter(subAdapter);
+            adapter.setSectionTitleAdapter(new SectionTitleAdapter(context, R.layout.list_header));
         }
         
         /**
@@ -555,6 +560,29 @@ public class SectionedListAdapter< T extends BaseAdapter> extends BaseAdapter im
          */
         public SectionedListAdapter.Builder<T> setSubAdapter(T subAdapter) {
             adapter.setSubAdapter(subAdapter);
+            return this;
+        }
+
+        /**
+         * Set the SectionTitleAdapter associated with the SectionedListAdapter
+         * adapter used to display headers
+         *
+         * @param subAdapter
+         * @return
+         */
+        public SectionedListAdapter.Builder<T> setSectionTitleAdapter(SectionTitleAdapter sectionTitleAdapter) {
+            adapter.setSectionTitleAdapter(sectionTitleAdapter);
+            return this;
+        }
+
+        /**
+         * Set the SectionTitleAdapter header layout associated with the SectionedListAdapter
+         *
+         * @param subAdapter
+         * @return
+         */
+        public SectionedListAdapter.Builder<T> setSectionTitleLayout(int layoutResourceId) {
+            adapter.setSectionTitleAdapter(new SectionTitleAdapter(context, layoutResourceId));
             return this;
         }
         

--- a/supersaiyan-scrollview/src/com/nolanlawson/supersaiyan/SectionedListAdapter.java
+++ b/supersaiyan-scrollview/src/com/nolanlawson/supersaiyan/SectionedListAdapter.java
@@ -514,10 +514,12 @@ public class SectionedListAdapter< T extends BaseAdapter> extends BaseAdapter im
     public static class Builder<T extends BaseAdapter> {
 
         private SectionedListAdapter<T> adapter;
+        private Context context;
 
         private Builder(Context context, T subAdapter) {
             adapter = new SectionedListAdapter<T>(context);
             adapter.setSubAdapter(subAdapter);
+            this.context = context;
             adapter.setSectionTitleAdapter(new SectionTitleAdapter(context, R.layout.list_header));
         }
         

--- a/supersaiyan-scrollview/src/com/nolanlawson/supersaiyan/SectionedListAdapter.java
+++ b/supersaiyan-scrollview/src/com/nolanlawson/supersaiyan/SectionedListAdapter.java
@@ -567,9 +567,9 @@ public class SectionedListAdapter< T extends BaseAdapter> extends BaseAdapter im
 
         /**
          * Set the SectionTitleAdapter associated with the SectionedListAdapter
-         * adapter used to display headers
+         * adapter used to display list headers
          *
-         * @param subAdapter
+         * @param sectionTitleAdapter
          * @return
          */
         public SectionedListAdapter.Builder<T> setSectionTitleAdapter(SectionTitleAdapter sectionTitleAdapter) {
@@ -580,7 +580,7 @@ public class SectionedListAdapter< T extends BaseAdapter> extends BaseAdapter im
         /**
          * Set the SectionTitleAdapter header layout associated with the SectionedListAdapter
          *
-         * @param subAdapter
+         * @param layoutResourceId
          * @return
          */
         public SectionedListAdapter.Builder<T> setSectionTitleLayout(int layoutResourceId) {


### PR DESCRIPTION
As we speak in #6 I've added the ability to set custom ListSectionAdapter or custom section header layout in the builder.

I've added it to the builder, so you can do it like that:

``` java
        final SectionedListAdapter<ListeableAdapter> sectionedAdapter =
                SectionedListAdapter.Builder.create(this, adapter)
                        .setSectionizer(new Sectionizer<Listeable>() {
                            @Override
                            public CharSequence toSection(Listeable item) {
                                return item.getType();
                            }
                        })
                        .setSectionTitleLayout(R.layout.my_custom_list_header)
                        .build();
```

Or even set your own custom adapter:

``` java
        final SectionedListAdapter<ListeableAdapter> sectionedAdapter =
                SectionedListAdapter.Builder.create(this, adapter)
                        .setSectionizer(new Sectionizer<Listeable>() {
                            @Override
                            public CharSequence toSection(Listeable item) {
                                return item.getType();
                            }
                        })
                        .setSectionTitleAdapter(new SectionTitleAdapter(this, R.layout.list_header) {
                            @Override
                            public View getView(int position, View view, ViewGroup parent) {
                                // do your own custom stuff
                            }
                        })
                        .build();
```

Without all that stuff provided, `ListSectionAdapter` will instantiate `SectionTitleAdapter` with `R.layout.list_header` parameter so nothing changes.

@nolanlawson I would be grateful if you find some time and review this.

Cheers!
