### PR TITLE
Refresh sections _before_ calling super.notifyDataSetChanged()

### DIFF
--- a/supersaiyan-scrollview/src/com/nolanlawson/supersaiyan/SectionedListAdapter.java
+++ b/supersaiyan-scrollview/src/com/nolanlawson/supersaiyan/SectionedListAdapter.java
@@ -185,8 +185,8 @@ public class SectionedListAdapter< T extends BaseAdapter> extends BaseAdapter im
 
     @Override
     public void notifyDataSetChanged() {
-        super.notifyDataSetChanged();
         refresh();
+        super.notifyDataSetChanged();
     }
     
     private void refresh() {


### PR DESCRIPTION
I had an issue with my list not updating when I changed some data in an underlying array of my ArrayAdapter unless I called notifyDataSetChanged() **twice**. Calling refresh() before super.notifyDataSetChanged() seems like a logical fix.
