### PR TITLE
Text overlapse overlay

### DIFF
--- a/supersaiyan-scrollview/res/values/attrs.xml
+++ b/supersaiyan-scrollview/res/values/attrs.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <declare-styleable name="SuperSaiyanScrollView">
+        <attr name="ssjn_overlayMaxTextLength" format="integer" />
         <attr name="ssjn_overlayWidth" format="dimension" />
         <attr name="ssjn_overlayHeight" format="dimension" />
         <attr name="ssjn_overlayTextSize" format="dimension" />
@@ -16,6 +17,7 @@
             <flag name="dark" value="0"/>
             <flag name="light" value="1"/>
         </attr>
+
         
     </declare-styleable>
 

--- a/supersaiyan-scrollview/src/com/nolanlawson/supersaiyan/widget/SuperSaiyanScrollView.java
+++ b/supersaiyan-scrollview/src/com/nolanlawson/supersaiyan/widget/SuperSaiyanScrollView.java
@@ -66,6 +66,7 @@ public class SuperSaiyanScrollView extends FrameLayout
     private int mOverlayWidth;
     private int mOverlayHeight;
     private float mOverlayTextSize;
+    private int mOverlayMaxTextLength;
 
     private boolean mDragging;
     private ListView mList;
@@ -161,6 +162,8 @@ public class SuperSaiyanScrollView extends FrameLayout
                 mOverlayWidth = getContext().getResources().getDimensionPixelSize(scheme.getWidth());
             }
             
+			mOverlayMaxTextLength = typedArray.getInteger(R.styleable.SuperSaiyanScrollView_ssjn_overlayMaxTextLength,-1);
+
             typedArray.recycle();
         } else {
             // no attrs, so initialize with defaults
@@ -444,7 +447,12 @@ public class SuperSaiyanScrollView extends FrameLayout
         }
 
         if (sectionIndex >= 0) {
-            String text = mSectionText = sections[sectionIndex].toString();
+            String sectionName = sections[sectionIndex].toString();
+            if(-1 < mOverlayMaxTextLength) {
+                sectionName = sectionName.substring(0, Math.min(mOverlayMaxTextLength, sectionName.length() - 1));
+                sectionName = sectionName.length() == mOverlayMaxTextLength ? sectionName + "..." : sectionName;
+            }
+            String text = mSectionText = sectionName;
             mDrawOverlay = (text.length() != 1 || text.charAt(0) != ' ') &&
                     sectionIndex < sections.length;
         } else {

--- a/supersaiyan-scrollview/src/com/nolanlawson/supersaiyan/widget/SuperSaiyanScrollView.java
+++ b/supersaiyan-scrollview/src/com/nolanlawson/supersaiyan/widget/SuperSaiyanScrollView.java
@@ -449,10 +449,10 @@ public class SuperSaiyanScrollView extends FrameLayout
         if (sectionIndex >= 0) {
             String sectionName = sections[sectionIndex].toString();
             if(-1 < mOverlayMaxTextLength) {
-                sectionName = sectionName.substring(0, Math.min(mOverlayMaxTextLength, sectionName.length() - 1));
+                sectionName = sectionName.substring(0, Math.min(mOverlayMaxTextLength, sectionName.length()));
                 sectionName = sectionName.length() == mOverlayMaxTextLength ? sectionName + "..." : sectionName;
             }
-            String text = mSectionText = sectionName;
+            String text = mSectionText =sectionName;
             mDrawOverlay = (text.length() != 1 || text.charAt(0) != ' ') &&
                     sectionIndex < sections.length;
         } else {


### PR DESCRIPTION
added option to restrict max length of overlay text to avoid "Text overlapse overlay" issue

if a shorter substring is created string ends with 3 dots - "..."

max text length can be set in xml.

if no length restriction is set, no changes will be made and the view behaves like before.
